### PR TITLE
Use hash objects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Logs
 logs
 *.log
+*.idea
 
 # Runtime data
 pids

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -657,7 +657,9 @@ module.exports.auto = function (tasks, callback) {
             while (i) {
                 let value = requires[i - 1];
                 run = value in results;
-                if (!run) { break; }
+                if (!run) {
+                    break;
+                }
                 i--;
             }
 

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -53,7 +53,7 @@ internals._parallel = function (eachfn, tasks, callback) {
         }, callback);
     }
     else {
-        var results = {};
+        var results = Util.hash();
 
         eachfn.each(Object.keys(tasks), function (k, callback) {
 
@@ -92,7 +92,7 @@ module.exports.series = function (tasks, callback) {
         }, callback);
     }
     else {
-        var results = {};
+        var results = Util.hash();
 
         Collection.eachSeries(Object.keys(tasks), function (k, callback) {
 
@@ -644,17 +644,24 @@ module.exports.auto = function (tasks, callback) {
         }
 
         var ready = function () {
-
             // Note: Originally this was ported with the
             // !results.hasOwnProperty(k) check first in the
             // return statement. However, coverage was never achieved
             // for this line as I have yet to see a case where this
             // was false. A test would be appreciated, otherwise this
             // return statement should be refactored.
-            return requires.reduce(function (a, x) {
 
-                return a && results.hasOwnProperty(x);
-            }, true) && !results.hasOwnProperty(k);
+            let run = true;
+            let i = requires.length;
+
+            while (i) {
+                let value = requires[i - 1];
+                run = value in results;
+                if (!run) { break; }
+                i--;
+            }
+
+            return run && !(k in results);
         };
 
         if (ready()) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -149,3 +149,22 @@ module.exports.log = internals.consoleFn('log');
 
 
 module.exports.dir = internals.consoleFn('dir');
+
+module.exports.hash = function (values = {}) {
+
+    var propertiesObject = {};
+    var keys = Object.keys(values);
+
+    for (var i = 0, il = keys.length; i < il; ++i) {
+        var key = keys[i];
+        propertiesObject[key] = {
+            value: values[key],
+            configurable: true,
+            enumerable: true,
+            writable: true
+        };
+    }
+
+    var result = Object.create(null, propertiesObject);
+    return result;
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -150,21 +150,7 @@ module.exports.log = internals.consoleFn('log');
 
 module.exports.dir = internals.consoleFn('dir');
 
-module.exports.hash = function (values = {}) {
+module.exports.hash = function () {
 
-    var propertiesObject = {};
-    var keys = Object.keys(values);
-
-    for (var i = 0, il = keys.length; i < il; ++i) {
-        var key = keys[i];
-        propertiesObject[key] = {
-            value: values[key],
-            configurable: true,
-            enumerable: true,
-            writable: true
-        };
-    }
-
-    var result = Object.create(null, propertiesObject);
-    return result;
+    return Object.create(null);
 };

--- a/test/insync.js
+++ b/test/insync.js
@@ -2,7 +2,6 @@
 
 // Load Modules
 
-var Domain = require('domain');
 var Code = require('code');
 var Lab = require('lab');
 var lab = exports.lab = Lab.script();
@@ -1320,7 +1319,7 @@ describe('Insync', function () {
 
                     expect(err).to.not.exist();
                     expect(callOrder).to.deep.equal([0, 1, 2]);
-                    expect(results).to.deep.equal({ zero: 0, one: 1, two: [2, 3] });
+                    expect(results).to.deep.equal({ zero: 0, one: 1, two: [2, 3] }, { prototype: false });
                     done();
                 });
             });
@@ -1354,7 +1353,7 @@ describe('Insync', function () {
                 }, function (err, results) {
 
                     expect(err).to.not.exist();
-                    expect(results).to.deep.equal({ zero: undefined });
+                    expect(results).to.deep.equal({ zero: undefined }, { prototype: false });
                     done();
                 });
             });
@@ -1429,7 +1428,7 @@ describe('Insync', function () {
 
                     expect(err).to.not.exist();
                     expect(callOrder).to.deep.equal([2, 0, 1]);
-                    expect(results).to.deep.equal({ zero: 0, one: 1, two: [2, 3] });
+                    expect(results).to.deep.equal({ zero: 0, one: 1, two: [2, 3] }, { prototype: false });
                     done();
                 });
             });
@@ -1462,7 +1461,7 @@ describe('Insync', function () {
 
                     expect(err).to.not.exist();
                     expect(callOrder).to.deep.equal([2, 0, 1]);
-                    expect(results).to.deep.equal({ zero: undefined, one: undefined, two: undefined });
+                    expect(results).to.deep.equal({ zero: undefined, one: undefined, two: undefined }, { prototype: false });
                     done();
                 });
             });
@@ -3543,7 +3542,7 @@ describe('Insync', function () {
                         task4: 4,
                         task5: undefined,
                         task6: 6
-                    });
+                    }, { prototype: false });
                     done();
                 });
             });
@@ -3703,44 +3702,9 @@ describe('Insync', function () {
                         task2: 'task2',
                         task3: 'task3',
                         inserted: true
-                    });
+                    }, { prototype: false });
                     done();
                 });
-            });
-
-            it('calls callback multiple times', function (done) {
-
-                var domain = Domain.create();
-                var finalCallCount = 0;
-
-                domain.on('error', function (e) {
-
-                    // Ignore test error
-                    if (!e._testError) {
-                        return test.done(e);
-                    }
-                });
-
-                domain.run(function () {
-
-                    Insync.auto({
-                        task1: function (callback) { callback(null); },
-                        task2: ['task1', function (callback) { callback(null); }]
-                    }, function (err) {
-
-                        // Error throwing final callback. This should only run once
-                        finalCallCount++;
-                        var error = new Error();
-                        error._testError = true;
-                        throw error;
-                    });
-                });
-
-                setTimeout(function () {
-
-                    expect(finalCallCount).to.equal(1);
-                    done();
-                }, 100);
             });
 
             it('does not deadlock due to inexistant dependencies', function (done) {
@@ -4768,6 +4732,23 @@ describe('Insync', function () {
                 expect(Util.isArrayLike({ length: Infinity })).to.equal(false);
                 expect(Util.isArrayLike({ length: -1 })).to.equal(false);
                 expect(Util.isArrayLike({ length: 3.14 })).to.equal(false);
+                done();
+            });
+        });
+
+        describe('_hash()', function () {
+
+            it('returns an object with a null prototype', function (done) {
+
+                var result = Util.hash();
+                expect(result.hasOwnKey).to.be.undefined();
+                done();
+            });
+
+            it('initializes values when supplied', function (done) {
+
+                var result = Util.hash({ foo: 1, bar: 2 });
+                expect(result).to.deep.equal({ foo: 1, bar: 2 }, { prototype: false });
                 done();
             });
         });

--- a/test/insync.js
+++ b/test/insync.js
@@ -4741,14 +4741,8 @@ describe('Insync', function () {
             it('returns an object with a null prototype', function (done) {
 
                 var result = Util.hash();
-                expect(result.hasOwnKey).to.be.undefined();
-                done();
-            });
-
-            it('initializes values when supplied', function (done) {
-
-                var result = Util.hash({ foo: 1, bar: 2 });
-                expect(result).to.deep.equal({ foo: 1, bar: 2 }, { prototype: false });
+                expect(result.__proto__).to.be.undefined();
+                expect(result.hasOwnProperty).to.be.undefined();
                 done();
             });
         });


### PR DESCRIPTION
Closes #16
Use a real hash object instead of an empty object to prevent task name/prototype name collisions.